### PR TITLE
Update for GetNameFromPrincipal for GroupPrincipal

### DIFF
--- a/src/AdAspNetProvider/ActiveDirectory/ActiveDirectory.cs
+++ b/src/AdAspNetProvider/ActiveDirectory/ActiveDirectory.cs
@@ -400,13 +400,16 @@ namespace AdAspNetProvider.ActiveDirectory
             string principalName = null;
             try
             {
-                // Extract name from underlying DirectoryEntry object.
-                principalName = ((DirectoryEntry)principal.GetUnderlyingObject()).Properties[this.Config.IdentityType.ToString()].Value.ToString();
-
                 // If principal is a group object, try to perform rename.
                 if (principal is GroupPrincipal)
                 {
+                    principalName = ((DirectoryEntry)principal.GetUnderlyingObject()).Properties[IdentityType.Name.ToString()].Value.ToString();
                     principalName = this.GetRenamedGroup(principalName);
+                }
+                else
+                {
+                    // Extract name from underlying DirectoryEntry object.
+                    principalName = ((DirectoryEntry)principal.GetUnderlyingObject()).Properties[this.Config.IdentityType.ToString()].Value.ToString();    
                 }
             }
             catch { }


### PR DESCRIPTION
When using IdentityType UserPrincipalName a group property name comes as NULL and the RoleProvider throws an exception.  Suggests to always use Name property for a Group.
